### PR TITLE
[HPB-145] [DevOps] backend .gitignore add “tmp”

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,6 @@ go.work.sum
 # Editor/IDE
 # .idea/
 # .vscode/
+
+# Docker temporary files
+/tmp/


### PR DESCRIPTION
[Issue Link](https://www.notion.so/DevOps-backend-gitignore-add-tmp-26ccba948f1180f4a3fbf93dda70fcf1?source=copy_link)

## Summary

- 在 .gitignore 中增加 /tmp/，以避免 docker 臨時檔案被 git 追蹤

## Detail

原本專案在 docker 構建後，會新增臨時檔案，且正在被 git 追蹤，如下圖

<img width="920" height="392" alt="Screenshot 2025-09-12 at 2 24 40 PM" src="https://github.com/user-attachments/assets/fc240e34-41d0-4b5a-b8c5-186ea3202e58" />

忽略 /tmp/ 後，即可避免 git add 時不小心把臨時檔案也加入 git